### PR TITLE
Fix Typo: Blue Enabled to Blur Enabled

### DIFF
--- a/usr/bin/settings.json
+++ b/usr/bin/settings.json
@@ -232,7 +232,7 @@
             "rows": [
                 {
                     "type": "SwitchRow",
-                    "title": "Blue Enabled",
+                    "title": "Blur Enabled",
                     "subtitle": "Enable kawase window background blur",
                     "keyword": "decoration:blur:enabled",
                     "default": true


### PR DESCRIPTION
Fixes typo for enabling blur under **Blur** in `Hyprland Settings`. 

Currently says "Blue Enabled".

![image](https://github.com/user-attachments/assets/db1a4c05-54aa-4b92-a23c-87d0a6201787)
