### PR TITLE
fix: sed unable to replace values in desktop file

### DIFF
--- a/com.ml4w.hyprland.settings.desktop
+++ b/com.ml4w.hyprland.settings.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=Application
 Name=ML4W_Hyprland_Settings
-Exec=com.ml4w.hyprland.settings
-Icon=com.ml4w.hyprland.settings
+Exec=HOME
+Icon=icon
 Terminal=false
 Categories=Utility

--- a/install.sh
+++ b/install.sh
@@ -100,12 +100,12 @@ if [ ! -d ~/apps ] ;then
 fi
 cp release/ML4W_Hyprland_Settings-x86_64.AppImage ~/apps
 cp com.ml4w.hyprland.settings.png ~/.local/share/applications/ml4w-hyprland-settings.png
-cp com.ml4w.hyprland.settings.desktop ~/.local/share/applications
+cp com.ml4w.hyprland.settings.desktop ~/.local/share/applications/
 
 APPIMAGE="$HOME/apps/ML4W_Hyprland_Settings-x86_64.AppImage"
 ICON="$HOME/.local/share/applications/ml4w-hyprland-settings.png"
-sed -i "s|HOME|${APPIMAGE}|g" $HOME/.local/share/applications/ml4w-hyprland-settings.desktop
-sed -i "s|icon|${ICON}|g" $HOME/.local/share/applications/ml4w-hyprland-settings.desktop
+sed -i "s|HOME|${APPIMAGE}|g" $HOME/.local/share/applications/com.ml4w.hyprland.settings.desktop
+sed -i "s|icon|${ICON}|g" $HOME/.local/share/applications/com.ml4w.hyprland.settings.desktop
 echo ":: Desktop file and icon installed successfully in ~/.local/share/applications"
 
 echo 


### PR DESCRIPTION
The desktop file was renamed to contain periods in commit ef0aeb1a4360ac2831275339fea3ad61d564ccbc but the sed command still takes the old file name.

The desktop file also did not contain values that sed was looking for.