### PR TITLE
fix(hyprctl-loader): wrap $1 and $i in quotes to handle keys/values containing spaces

### DIFF
--- a/src/scripts/hyprctl.sh
+++ b/src/scripts/hyprctl.sh
@@ -17,13 +17,13 @@ fi
 
 jq -c '.[]' $path/hyprctl.json | while read i; do
     _val() {
-        echo $1 | jq -r '.value'
+        echo "$1" | jq -r '.value'
     }
     _key() {
-        echo $1 | jq -r '.key'
+        echo "$1" | jq -r '.key'
     }
-    key=$(_key $i)
-    val=$(_val $i)
+    key=$(_key "$i")
+    val=$(_val "$i")
     echo ":: Execute: hyprctl keyword $key $val"
     hyprctl keyword $key $val
 done


### PR DESCRIPTION
fix(hyprctl-loader): wrap $1 and $i in quotes to handle keys/values containing spaces