### PR TITLE
Fixed an issue where an empty hyprctl.json from config will result in a JSON Deocde error.

### DIFF
--- a/src/library/library.py
+++ b/src/library/library.py
@@ -23,7 +23,19 @@ class Library:
 
     # Load content from hyprctl.json
     def loadHyprctlJson(self):
-        hyprctl_json = open(configFolder + "/hyprctl.json")
+        # hyprctl_json = open(configFolder + "/hyprctl.json")
+        path = configFolder + "/hyprctl.json"
+        try:
+            # If the file is empty then copy the shipped one
+            if os.path.getsize(path) == 0:
+                shutil.copy(path_name + '/json/hyprctl.json', configFolder)
+                hyprctl_json = open(path)
+            # else load normally
+            else:
+                hyprctl_json = open(path)
+        except (json.JSONDecodeError, FileNotFoundError) as err:
+            print(":: Error loading hyprctl.json")
+
         return hyprctl_json
 
     def writeHyprctlJson(self,result):


### PR DESCRIPTION
Fixes the issue where an empty hpyrctl.json is loaded resulting to a JSON Decode error which in result stops the app from loading at all or often leads to empty list in all varibales list.

The fix simply checks if the file is empty or not, if the hyprctl.json is empty then copies the default to the config path.

Currently an empty hyprctl.json results in: 
<img width="925" height="832" alt="screenshot_04092025_225334" src="https://github.com/user-attachments/assets/ecc5ffc0-f12f-400b-aa06-bfcf9ddc63c2" />
